### PR TITLE
Change of names and improvements to panels

### DIFF
--- a/904_GEM_PMTs/panels/904_GEM_PMTs/904_GEM_PMT_panel.pnl
+++ b/904_GEM_PMTs/panels/904_GEM_PMTs/904_GEM_PMT_panel.pnl
@@ -1,0 +1,386 @@
+V 14
+1
+LANG:1 0 
+PANEL,-1 -1 1657 638 N "_3DFace" 0
+E E E E E 1 -1 -1 0  102.2177737515632 49.68048671722551
+""0  1
+E E 3
+"CBRef" "1"
+"EClose" E
+"dpi" "96"
+0 0 0
+""
+DISPLAY_LAYER, 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0
+LAYER, 0 
+1
+LANG:1 0 
+1 149 0 "" 1
+0
+1 173 1 "" 1
+0
+1 197 2 "" 1
+0
+1 221 3 "" 1
+0
+1 245 4 "" 1
+0
+2 139
+"PRIMITIVE_TEXT14"
+""
+1 20 10 E E E 1 E 1 E N {12,12,140,246} E N "_Window" E E
+ E E
+7 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+4
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+"transformable" "0"
+E E 0 1 3 2 1 E 0.5520833333333334 0 1 3.062499999999984 -0.8148148148146677 0 E 20 10 400 27
+0 2 2 "0s" 0 0 0 64 0 0  20 10 2
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 25 Board 1 Ch. 000 / PMT 001
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 0 
+2 140
+"PRIMITIVE_TEXT15"
+""
+1 20 10 E E E 1 E 1 E N {12,12,140} E N "_Window" E E
+ E E
+8 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+4
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+"transformable" "0"
+E E 0 1 3 2 1 E 0.5520833333333334 0 1 333.4601215759263 -1.314814814814529 0 E 20 10 400 27
+0 2 2 "0s" 0 0 0 64 0 0  20 10 2
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 25 Board 1 Ch. 001 / PMT 002
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 0 
+2 141
+"PRIMITIVE_TEXT16"
+""
+1 20 10 E E E 1 E 1 E N {12,12,140} E N "_Window" E E
+ E E
+9 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+4
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+"transformable" "0"
+E E 0 1 3 2 1 E 0.5520833333333334 0 1 664.0625 -0.814814814814667 0 E 20 10 400 27
+0 2 2 "0s" 0 0 0 64 0 0  20 10 2
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 25 Board 1 Ch. 002 / PMT 003
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 0 
+2 142
+"PRIMITIVE_TEXT17"
+""
+1 20 10 E E E 1 E 1 E N {12,12,140} E N "_Window" E E
+ E E
+10 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+4
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+"transformable" "0"
+E E 0 1 3 2 1 E 0.5520833333333334 0 1 993.848010631448 -1.000000000000092 0 E 20 10 400 27
+0 2 2 "0s" 0 0 0 64 0 0  20 10 2
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 24 Board 1 Ch. 003 /PMT 004
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 0 
+2 143
+"PRIMITIVE_TEXT18"
+""
+1 20 10 E E E 1 E 1 E N {12,12,140} E N "_Window" E E
+ E E
+11 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+4
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+"transformable" "0"
+E E 0 1 3 2 1 E 0.5520833333333334 0 1 1323.690289852097 -3.000000000000092 0 E 20 10 400 27
+0 2 2 "0s" 0 0 0 64 0 0  20 10 2
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 25 Board 1 Ch. 004 / PMT 005
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 0 
+2 144
+"PRIMITIVE_TEXT19"
+""
+1 20 10 E E E 1 E 1 E N {12,12,140} E N "_Window" E E
+ E E
+12 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+4
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+"transformable" "0"
+E E 0 1 3 2 1 E 0.5520833333333334 0 1 4.068656035218449 329.5 0 E 20 10 400 27
+0 2 2 "0s" 0 0 0 64 0 0  20 10 2
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 25 Board 2 Ch. 000 / PMT 006
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 0 
+2 145
+"PRIMITIVE_TEXT20"
+""
+1 20 10 E E E 1 E 1 E N {12,12,140} E N "_Window" E E
+ E E
+13 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+4
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+"transformable" "0"
+E E 0 1 3 2 1 E 0.5520833333333334 0 1 333.5799671502119 329.5 0 E 20 10 400 27
+0 2 2 "0s" 0 0 0 64 0 0  20 10 2
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 25 Board 2 Ch. 001 / PMT 007
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 0 
+2 146
+"PRIMITIVE_TEXT21"
+""
+1 20 10 E E E 1 E 1 E N {12,12,140} E N "_Window" E E
+ E E
+14 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+4
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+"transformable" "0"
+E E 0 1 3 2 1 E 0.5520833333333334 0 1 663.952177298115 329.5 0 E 20 10 400 27
+0 2 2 "0s" 0 0 0 64 0 0  20 10 2
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 25 Board 2 Ch. 002 / PMT 008
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 0 
+2 147
+"PRIMITIVE_TEXT22"
+""
+1 20 10 E E E 1 E 1 E N {12,12,140} E N "_Window" E E
+ E E
+15 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+4
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+"transformable" "0"
+E E 0 1 3 2 1 E 0.5520833333333334 0 1 993.848010631448 329.5 0 E 20 10 400 27
+0 2 2 "0s" 0 0 0 64 0 0  20 10 2
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 25 Board 2 Ch. 003 / PMT 009
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 0 
+2 148
+"PRIMITIVE_TEXT23"
+""
+1 20 10 E E E 1 E 1 E N {12,12,140} E N "_Window" E E
+ E E
+16 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+4
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+"transformable" "0"
+E E 0 1 3 2 1 E 0.5520833333333334 0 1 1323.690289852097 329.5 0 E 20 10 400 27
+0 2 2 "0s" 0 0 0 64 0 0  20 10 2
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 25 Board 2 Ch. 004 / PMT 010
+1
+LANG:1 30 Open Sans,-1,15,5,75,0,0,0,0,0
+0 1
+LANG:1 0 
+1 269 5 "" 1
+0
+1 293 6 "" 1
+0
+1 317 7 "" 1
+0
+1 341 8 "" 1
+0
+1 365 9 "" 1
+0
+0
+LAYER, 1 
+1
+LANG:1 0 
+0
+LAYER, 2 
+1
+LANG:1 0 
+0
+LAYER, 3 
+1
+LANG:1 0 
+0
+LAYER, 4 
+1
+LANG:1 0 
+0
+LAYER, 5 
+1
+LANG:1 0 
+0
+LAYER, 6 
+1
+LANG:1 0 
+0
+LAYER, 7 
+1
+LANG:1 0 
+0
+3 0 "PANEL_REF0" -1
+"layoutAlignment" "AlignNone"
+"" ""
+"Cosmic_GEM_CAEN/904_GEM_PMT_ref.pnl" 135.3078853626942 49.484375 T 1 1 0 1 -60.30788536269421 31.515625
+1
+"$dpChnName""cms_gem_dcs_1:CAEN/904_Shared_mainframe/board02/channel000"
+3 1 "PANEL_REF1" -1
+"layoutAlignment" "AlignNone"
+"" ""
+"Cosmic_GEM_CAEN/904_GEM_PMT_ref.pnl" 497 41.36111111111137 T 2 1 0 1 -92 39.63888888888863
+1
+"$dpChnName""cms_gem_dcs_1:CAEN/904_Shared_mainframe/board02/channel001"
+3 2 "PANEL_REF2" -1
+"layoutAlignment" "AlignNone"
+"" ""
+"Cosmic_GEM_CAEN/904_GEM_PMT_ref.pnl" 940 41.3611111111112 T 3 1 0 1 -204 39.6388888888888
+1
+"$dpChnName""cms_gem_dcs_1:CAEN/904_Shared_mainframe/board02/channel002"
+3 3 "PANEL_REF3" -1
+"layoutAlignment" "AlignNone"
+"" ""
+"Cosmic_GEM_CAEN/904_GEM_PMT_ref.pnl" 1285 42.38888888888906 T 4 1 0 1 -220 38.61111111111094
+1
+"$dpChnName""cms_gem_dcs_1:CAEN/904_Shared_mainframe/board02/channel003"
+3 4 "PANEL_REF4" -1
+"layoutAlignment" "AlignNone"
+"" ""
+"Cosmic_GEM_CAEN/904_GEM_PMT_ref.pnl" 1693 41.72222222222348 T 5 1 0 1 -298 39.27777777777652
+1
+"$dpChnName""cms_gem_dcs_1:CAEN/904_Shared_mainframe/board02/channel004"
+3 5 "PANEL_REF5" -1
+"layoutAlignment" "AlignNone"
+"" ""
+"Cosmic_GEM_CAEN/904_GEM_PMT_ref.pnl" 85.00615603521845 452.0000000000001 T 17 1 0 1 -10.00615603521845 -40.00000000000011
+1
+"$dpChnName""cms_gem_dcs_1:CAEN/904_Shared_mainframe/board04/channel000"
+3 6 "PANEL_REF6" -1
+"layoutAlignment" "AlignNone"
+"" ""
+"Cosmic_GEM_CAEN/904_GEM_PMT_ref.pnl" 492.8896772981149 452.0000000000001 T 18 1 0 1 -87.88967729811492 -40.00000000000011
+1
+"$dpChnName""cms_gem_dcs_1:CAEN/904_Shared_mainframe/board04/channel001"
+3 7 "PANEL_REF7" -1
+"layoutAlignment" "AlignNone"
+"" ""
+"Cosmic_GEM_CAEN/904_GEM_PMT_ref.pnl" 894 452.0000000000001 T 19 1 0 1 -159 -40.00000000000011
+1
+"$dpChnName""cms_gem_dcs_1:CAEN/904_Shared_mainframe/board04/channel002"
+3 8 "PANEL_REF8" -1
+"layoutAlignment" "AlignNone"
+"" ""
+"Cosmic_GEM_CAEN/904_GEM_PMT_ref.pnl" 1300.834515947172 451.4999999999999 T 20 1 0 1 -235.834515947172 -39.49999999999989
+1
+"$dpChnName""cms_gem_dcs_1:CAEN/904_Shared_mainframe/board04/channel003"
+3 9 "PANEL_REF9" -1
+"layoutAlignment" "AlignNone"
+"" ""
+"Cosmic_GEM_CAEN/904_GEM_PMT_ref.pnl" 1713.895833333333 450.0000000000001 T 21 1 0 1 -318.8958333333331 -38.00000000000011
+1
+"$dpChnName""cms_gem_dcs_1:CAEN/904_Shared_mainframe/board04/channel004"
+0

--- a/904_GEM_PMTs/panels/904_GEM_PMTs/904_GEM_PMT_ref.pnl
+++ b/904_GEM_PMTs/panels/904_GEM_PMTs/904_GEM_PMT_ref.pnl
@@ -1,0 +1,973 @@
+V 14
+1
+LANG:1 7 Button1
+PANEL,-1 -1 323 255 N "_3DFace" 1
+"$dpChnName"
+"main()
+{
+
+
+}" 0
+ E E E E 1 -1 -1 0  70 50
+""0  1
+E E 3
+"CBRef" "1"
+"EClose" E
+"dpi" "96"
+0 0 0
+""
+DISPLAY_LAYER, 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0
+LAYER, 0 
+1
+LANG:1 0 
+2 1
+"PRIMITIVE_TEXT1"
+""
+1 70 50 E E E 1 E 1 E N "_WindowText" E N "_Window" E E
+ E E
+0 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+4
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+"transformable" "0"
+E E 0 1 3 2 1 E 0.6389548043574663 0 0.2388409457425784 -27.45987028788717 34.08692906930663 0 E 70 50 180 100
+0 2 2 "0s" 0 0 0 64 0 0  70 50 1
+1
+LANG:1 31 Sans Serif,-1,12,5,50,0,0,0,0,0
+0 1
+LANG:1 11 Voltage (V)
+2 3
+"PRIMITIVE_TEXT3"
+""
+1 70 50 E E E 1 E 1 E N "_WindowText" E N "_Window" E E
+ E E
+2 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+4
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+"transformable" "0"
+E E 0 1 3 2 1 E 0.6299231319465035 0 0.3720130285227238 -26.64601001426363 59.07781923883036 0 E 70 50 180 100
+0 2 2 "0s" 0 0 0 64 0 0  70 50 1
+1
+LANG:1 31 Sans Serif,-1,12,5,50,0,0,0,0,0
+0 1
+LANG:1 9 I max (A)
+2 7
+"PRIMITIVE_TEXT7"
+""
+1 70 50 E E E 1 E 1 E N "_WindowText" E N "_Window" E E
+ E E
+6 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+4
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+"transformable" "0"
+E E 0 1 3 2 1 E 0.6400982537031364 0 0.3374423055274118 133.4814886844568 29.580884836204 0 E 70 50 180 100
+0 2 2 "0s" 0 0 0 64 0 0  70 50 1
+1
+LANG:1 31 Sans Serif,-1,12,5,50,0,0,0,0,0
+0 1
+LANG:1 11 Voltage (V)
+2 8
+"PRIMITIVE_TEXT8"
+""
+1 70 50 E E E 1 E 1 E N "_WindowText" E N "_Window" E E
+ E E
+7 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+4
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+"transformable" "0"
+E E 0 1 3 2 1 E 0.6062176165803109 0 0.4074074074074074 135.4676165803109 57.62962962962963 0 E 70 50 180 100
+0 2 2 "0s" 0 0 0 64 0 0  70 50 1
+1
+LANG:1 31 Sans Serif,-1,12,5,50,0,0,0,0,0
+0 1
+LANG:1 11 Current (A)
+2 9
+"PRIMITIVE_TEXT9"
+""
+1 70 50 E E E 1 E 1 E N "_WindowText" E N "_Window" E E
+ E E
+8 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+4
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+"transformable" "0"
+E E 0 1 3 2 1 E 0.6316228546592644 0 0.4074074074074074 -26.95535954798615 85.46527777777776 0 E 70 50 180 100
+0 2 2 "0s" 0 0 0 64 0 0  70 50 1
+1
+LANG:1 31 Sans Serif,-1,12,5,50,0,0,0,0,0
+0 1
+LANG:1 9 V max (V)
+13 12
+"PUSH_BUTTON3"
+""
+1 196.0631085558047 217.6052083333333 E E E 1 E 1 E N "_ButtonText" E N "WF_Info" E E
+ E E
+11 0 0 0 0 0
+E E E
+8
+1
+LANG:1 0 
+
+1
+"layoutAlignment" "AlignNone"
+1
+LANG:1 31 Sans Serif,-1,15,5,50,0,0,0,0,0
+0  194.0631085558046 209.1052083333333 275.2471759133175 242.1052083333333
+
+T 
+1
+LANG:1 6 On/Off
+"// SimpleCtrlScriptStart {invalid}
+main()
+{
+  EP_toggleDP();
+}
+
+void EP_toggleDP()
+{
+bool bo;
+
+  dpGet($dpChnName+\".settings.onOff:_online.._value\", bo);
+  dpSet($dpChnName+\".settings.onOff:_original.._value\", !bo);
+}
+
+// SimpleCtrlScript {EP_toggleDP}
+// DP {cms_gem_dcs_1:CAEN/904_Shared_mainframe/board02/channel000.settings.onOff}
+// Config {:_original.._value}
+// DPType {bool}
+// SimpleCtrlScriptEnd {EP_toggleDP}
+" 0
+ E E "main()
+{
+
+}
+
+" 0
+
+14 14
+"Vset"
+""
+1 99.75 46 E E E 1 E 1 E N "_WindowText" E N "_Window" E E
+ E E
+13 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+1
+"layoutAlignment" "AlignNone"
+1
+LANG:1 31 Sans Serif,-1,12,5,50,0,0,0,0,0
+0  97.75 35 150.75 69
+3 "0.1f" 2 0 0 0 0 -1  E "// SimpleCtrlScriptStart {invalid}
+main()
+{
+  EP_textFieldIn();
+}
+
+void EP_textFieldIn()
+{
+  dyn_errClass err;
+
+  if( !dpExists( $dpChnName+\".readBackSettings.v0:_online.._value\"))
+  {
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+    return;
+  }
+
+  dpConnect(\"EP_textFieldInCB\",$dpChnName+\".readBackSettings.v0:_online.._value\");
+  err = getLastError();
+  if (dynlen(err) > 0)
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+
+}
+
+
+void EP_textFieldInCB(string dp, float fNewValue)
+{
+  setValue(\"\", \"text\", fNewValue);
+}
+
+// SimpleCtrlScript {EP_textFieldIn}
+// DP {cms_gem_dcs_1:CAEN/904_Shared_mainframe/board02/channel000.readBackSettings.v0}
+// DPConfig {:_online.._value}
+// DPType {float}
+// UseDPUnit {FALSE}
+// UseDPFormat {FALSE}
+// SimpleCtrlScriptEnd {EP_textFieldIn}
+" 0
+ E
+14 15
+"Imax"
+""
+1 100 76 E E E 1 E 1 E N "_WindowText" E N "_Window" E E
+ E E
+14 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+1
+"layoutAlignment" "AlignNone"
+1
+LANG:1 31 Sans Serif,-1,12,5,50,0,0,0,0,0
+0  98 65 151 99
+3 "0.1f" 2 0 0 0 0 -1  E "// SimpleCtrlScriptStart {invalid}
+main()
+{
+  EP_textFieldIn();
+}
+
+void EP_textFieldIn()
+{
+  dyn_errClass err;
+
+  if( !dpExists( $dpChnName+\".readBackSettings.i0:_online.._value\"))
+  {
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+    return;
+  }
+
+  dpConnect(\"EP_textFieldInCB\",
+            $dpChnName+\".readBackSettings.i0:_online.._value\");
+  err = getLastError();
+  if (dynlen(err) > 0)
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+
+}
+
+
+void EP_textFieldInCB(string dp, float fNewValue)
+{
+  setValue(\"\", \"text\", fNewValue);
+}
+
+// SimpleCtrlScript {EP_textFieldIn}
+// DP {cms_gem_dcs_1:CAEN/904_Shared_mainframe/board02/channel000.readBackSettings.i0}
+// DPConfig {:_online.._value}
+// DPType {float}
+// UseDPUnit {FALSE}
+// UseDPFormat {FALSE}
+// SimpleCtrlScriptEnd {EP_textFieldIn}
+" 0
+ E
+14 16
+"Vmax"
+""
+1 100 106.0231481481482 E E E 1 E 1 E N "_WindowText" E N "_Window" E E
+ E E
+15 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+1
+"layoutAlignment" "AlignNone"
+1
+LANG:1 31 Sans Serif,-1,12,5,50,0,0,0,0,0
+0  98 95 151 129
+3 "0.1f" 2 0 0 0 0 -1  E "// SimpleCtrlScriptStart {invalid}
+main()
+{
+  EP_textFieldIn();
+}
+
+void EP_textFieldIn()
+{
+  dyn_errClass err;
+
+  if( !dpExists( $dpChnName+\".readBackSettings.vMaxSoftValue:_online.._value\"))
+  {
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+    return;
+  }
+
+  dpConnect(\"EP_textFieldInCB\",$dpChnName+\".readBackSettings.vMaxSoftValue:_online.._value\");
+  err = getLastError();
+  if (dynlen(err) > 0)
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+
+}
+
+
+void EP_textFieldInCB(string dp, float fNewValue)
+{
+  setValue(\"\", \"text\", fNewValue);
+}
+
+// SimpleCtrlScript {EP_textFieldIn}
+// DP {cms_gem_dcs_1:CAEN/904_Shared_mainframe/board02/channel000.readBackSettings.vMaxSoftValue}
+// DPConfig {:_online.._value}
+// DPType {float}
+// UseDPUnit {FALSE}
+// UseDPFormat {FALSE}
+// SimpleCtrlScriptEnd {EP_textFieldIn}
+" 0
+ E
+14 17
+"TEXT_FIELD4"
+""
+1 254.8976683937825 46.00000000000001 E E E 1 E 1 E N "_WindowText" E N "White" E E
+ E E
+16 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+1
+"layoutAlignment" "AlignNone"
+1
+LANG:1 31 Sans Serif,-1,12,5,50,0,0,0,0,0
+0  253 35 306 69
+3 "0.1f" 2 0 0 0 0 -1  E "// SimpleCtrlScriptStart {invalid}
+main()
+{
+  EP_textFieldIn();
+  EP_setBackColor();
+}
+
+void EP_textFieldIn()
+{
+  dyn_errClass err;
+
+  if( !dpExists( $dpChnName+\".actual.vMon:_online.._value\"))
+  {
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+    return;
+  }
+
+  dpConnect(\"EP_textFieldInCB\",
+            $dpChnName+\".actual.vMon:_online.._value\");
+  err = getLastError();
+  if (dynlen(err) > 0)
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+
+}
+
+
+void EP_textFieldInCB(string dp, float fNewValue)
+{
+  setValue(\"\", \"text\", fNewValue);
+}
+
+// SimpleCtrlScript {EP_textFieldIn}
+// DP {cms_gem_dcs_1:CAEN/904_Shared_mainframe/board02/channel000.actual.vMon}
+// DPConfig {:_online.._value}
+// DPType {float}
+// UseDPUnit {FALSE}
+// UseDPFormat {FALSE}
+// SimpleCtrlScriptEnd {EP_textFieldIn}
+
+void EP_setBackColor()
+{
+  dyn_errClass err;
+
+  if( !dpExists( $dpChnName+\".actual.isOn:_online.._value\"))
+  {
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+    return;
+  }
+
+  dpConnect(\"EP_setBackColorCB\", 
+            $dpChnName+\".actual.isOn:_online.._value\");
+  err = getLastError();
+  if (dynlen(err) > 0)
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+
+}
+
+
+void EP_setBackColorCB(string dpSource, bool boNewValue)
+{
+  if (!boNewValue)
+    setValue(\"\", \"backCol\", \"white\");
+  else
+    setValue(\"\", \"backCol\", \"{154,255,110,246}\");
+}
+" 0
+ E
+14 18
+"TEXT_FIELD5"
+""
+1 255.1556023316063 76.00000000000001 E E E 1 E 1 E N "_WindowText" E N "_Window" E E
+ E E
+17 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+1
+"layoutAlignment" "AlignNone"
+1
+LANG:1 31 Sans Serif,-1,12,5,50,0,0,0,0,0
+0  253 65 306 99
+3 "0.1f" 2 0 0 0 0 -1  E "// SimpleCtrlScriptStart {invalid}
+main()
+{
+  EP_textFieldIn();
+}
+
+void EP_textFieldIn()
+{
+  dyn_errClass err;
+
+  if( !dpExists( $dpChnName+\".actual.iMon:_online.._value\"))
+  {
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+    return;
+  }
+
+  dpConnect(\"EP_textFieldInCB\",
+            $dpChnName+\".actual.iMon:_online.._value\");
+  err = getLastError();
+  if (dynlen(err) > 0)
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+
+}
+
+
+void EP_textFieldInCB(string dp, float fNewValue)
+{
+  setValue(\"\", \"text\", fNewValue);
+}
+
+// SimpleCtrlScript {EP_textFieldIn}
+// DP {cms_gem_dcs_1:CAEN/904_Shared_mainframe/board02/channel000.actual.iMon}
+// DPConfig {:_online.._value}
+// DPType {float}
+// UseDPUnit {FALSE}
+// UseDPFormat {FALSE}
+// SimpleCtrlScriptEnd {EP_textFieldIn}
+" 0
+ E
+30 20
+"FRAME1"
+""
+1 17 58 E E E 1 E 1 E N "_WindowText" E N {0,0,0} E E
+ E E
+19 0 0 0 0 0
+E E E
+1
+1
+LANG:1 0 
+
+3
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+E E 0 1 3 2 1 E 0.6726457399103141 0 0.9217557251908401 -3.434977578475358 -44.96183206106884 0 E 17 58 241 321
+1
+LANG:1 31 Sans Serif,-1,16,5,50,0,0,0,0,0
+0 1
+LANG:1 8 Settings
+30 21
+"FRAME2"
+""
+1 17 58 E E E 1 E 1 E N "_WindowText" E N {0,0,0} E E
+ E E
+20 0 0 0 0 0
+E E E
+1
+1
+LANG:1 0 
+
+3
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+E E 0 1 3 2 1 E 0.64731613283524 0 0.5846762793327671 158.995625741801 -25.72603901611516 0 E 17 58 241 321
+1
+LANG:1 31 Sans Serif,-1,16,5,50,0,0,0,0,0
+0 1
+LANG:1 6 Actual
+13 22
+"Button_set"
+""
+1 58.00000000000001 207.2104166666667 E E E 1 E 1 E N "_ButtonText" E N "WF_Info" E E
+ E E
+21 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+1
+"layoutAlignment" "AlignNone"
+1
+LANG:1 30 Open Sans,-1,15,5,50,0,0,0,0,0
+0  56.00000000000001 208.2104166666667 140 242.2104166666667
+
+T 
+1
+LANG:1 3 Set
+"main(mapping event)
+{
+  dyn_string exceptionInfo;
+  bool answ;
+  fwGeneral_openMessagePanel(\"Is it OK to write new values?\",answ,exceptionInfo,\"confirm\",false);
+  Debug(\"answer\",answ);
+  if(answ)
+  {
+    applyChange();
+  }
+}
+  
+applyChange()
+{
+ string v0,imax,vmax,rmpup,rmpdwn; 
+   getValue(\"Vset\",\"text\",v0);
+   getValue(\"Imax\",\"text\",imax);
+   getValue(\"Vmax\",\"text\",vmax);
+   getValue(\"Rmpup\",\"text\",rmpup);   
+   getValue(\"Rmpdown\",\"text\",rmpdwn);
+   dpSet($dpChnName+\".settings.v0:_original.._value\",v0);
+   dpSet($dpChnName+\".settings.i0:_original.._value\",imax);
+   dpSet($dpChnName+\".settings.vMaxSoftValue:_original.._value\",vmax);
+   dpSet($dpChnName+\".settings.rUp:_original.._value\",rmpup);
+   dpSet($dpChnName+\".settings.rDwn:_original.._value\",rmpdwn);  
+}" 0
+ E E E
+14 23
+"Rmpup"
+""
+1 99.99999999999997 136.0208333333333 E E E 1 E 1 E N "_WindowText" E N "_Window" E E
+ E E
+22 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+1
+"layoutAlignment" "AlignNone"
+1
+LANG:1 31 Sans Serif,-1,12,5,50,0,0,0,0,0
+0  98 125 151 159
+3 "0.1f" 2 0 0 0 0 -1  E "// SimpleCtrlScriptStart {invalid}
+main()
+{
+  EP_textFieldIn();
+}
+
+void EP_textFieldIn()
+{
+  dyn_errClass err;
+
+  if( !dpExists( $dpChnName+\".readBackSettings.rUp:_online.._value\"))
+  {
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+    return;
+  }
+
+  dpConnect(\"EP_textFieldInCB\",
+            $dpChnName+\".readBackSettings.rUp:_online.._value\");
+  err = getLastError();
+  if (dynlen(err) > 0)
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+
+}
+
+
+void EP_textFieldInCB(string dp, float fNewValue)
+{
+  setValue(\"\", \"text\", fNewValue);
+}
+
+// SimpleCtrlScript {EP_textFieldIn}
+// DP {cms_gem_dcs_1:CAEN/904_Shared_mainframe/board02/channel000.readBackSettings.rUp}
+// DPConfig {:_online.._value}
+// DPType {float}
+// UseDPUnit {FALSE}
+// UseDPFormat {FALSE}
+// SimpleCtrlScriptEnd {EP_textFieldIn}
+" 0
+ E
+2 24
+"PRIMITIVE_TEXT10"
+""
+1 70 50 E E E 1 E 1 E N "_WindowText" E N "_Window" E E
+ E E
+23 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+4
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+"transformable" "0"
+E E 0 1 3 2 1 E 0.6565951930102709 0 0.2873677248677254 -28.50032512786935 122.2271825396825 0 E 70 50 180 100
+0 2 2 "0s" 0 0 0 64 0 0  70 50 1
+1
+LANG:1 31 Sans Serif,-1,12,5,50,0,0,0,0,0
+0 1
+LANG:1 10 Rmp Up (V)
+14 25
+"Rmpdown"
+""
+1 100 166.0104166666667 E E E 1 E 1 E N "_WindowText" E N "_Window" E E
+ E E
+24 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+1
+"layoutAlignment" "AlignNone"
+1
+LANG:1 31 Sans Serif,-1,12,5,50,0,0,0,0,0
+0  98 155 151 189
+3 "0.1f" 2 0 0 0 0 -1  E "// SimpleCtrlScriptStart {invalid}
+main()
+{
+  EP_textFieldIn();
+}
+
+void EP_textFieldIn()
+{
+  dyn_errClass err;
+
+  if( !dpExists( $dpChnName+\".readBackSettings.rUp:_online.._value\"))
+  {
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+    return;
+  }
+
+  dpConnect(\"EP_textFieldInCB\",
+            $dpChnName+\".readBackSettings.rUp:_online.._value\");
+  err = getLastError();
+  if (dynlen(err) > 0)
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+
+}
+
+
+void EP_textFieldInCB(string dp, float fNewValue)
+{
+  setValue(\"\", \"text\", fNewValue);
+}
+
+// SimpleCtrlScript {EP_textFieldIn}
+// DP {cms_gem_dcs_1:CAEN/904_Shared_mainframe/board02/channel000.readBackSettings.rUp}
+// DPConfig {:_online.._value}
+// DPType {float}
+// UseDPUnit {FALSE}
+// UseDPFormat {FALSE}
+// SimpleCtrlScriptEnd {EP_textFieldIn}
+" 0
+ E
+2 26
+"PRIMITIVE_TEXT11"
+""
+1 70 50 E E E 1 E 1 E N "_WindowText" E N "_Window" E E
+ E E
+25 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+4
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+"transformable" "0"
+E E 0 1 3 2 1 E 0.7428650215990081 0 0.4074074074074074 -34.73990240591754 144.6666666666666 0 E 70 50 180 100
+0 2 2 "0s" 0 0 0 64 0 0  70 50 2
+1
+LANG:1 31 Sans Serif,-1,12,5,50,0,0,0,0,0
+0 1
+LANG:1 11 Rmp Dwn (V)
+1
+LANG:1 31 Sans Serif,-1,12,5,50,0,0,0,0,0
+0 1
+LANG:1 0 
+14 27
+"TEXT_FIELD8"
+""
+1 254.5119818652851 106.0046296296296 E E E 1 E 1 E N "_WindowText" E N "_Window" E E
+ E E
+26 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+1
+"layoutAlignment" "AlignNone"
+1
+LANG:1 31 Sans Serif,-1,12,5,50,0,0,0,0,0
+0  253 95 306 129
+3 "0s" 0 0 0 1 0 -1  E "// SimpleCtrlScriptStart {invalid}
+main()
+{
+  EP_textFieldIn();
+}
+
+void EP_textFieldIn()
+{
+  dyn_errClass err;
+
+  if( !dpExists($dpChnName+\".actual.rampingDirection:_online.._value\"))
+  {
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+    return;
+  }
+
+  dpConnect(\"EP_textFieldInCB\",
+            $dpChnName+\".actual.rampingDirection:_online.._value\");
+  err = getLastError();
+  if (dynlen(err) > 0)
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+
+}
+
+void EP_textFieldInCB(string dp, int iNewValue)
+{
+ // setValue(\"\", \"text\", dpValToString(dp, iNewValue, FALSE) );
+  if ( iNewValue == 0 ) 
+  { 
+     setValue(\"\", \"text\", \"UP\" );
+  } else 
+  {
+     setValue(\"\", \"text\", \"DOWN\" ); 
+  }
+}
+
+// SimpleCtrlScript {EP_textFieldIn}
+// DP {cms_gem_dcs_1:CAEN/904_Shared_mainframe/board02/channel000.actual.rampingDirection}
+// DPConfig {:_online.._value}
+// DPType {int}
+// UseDPUnit {FALSE}
+// UseDPFormat {TRUE}
+// SimpleCtrlScriptEnd {EP_textFieldIn}
+" 0
+ E
+14 28
+"TEXT_FIELD9"
+""
+1 254.8770239637307 136.224537037037 E E E 1 E 1 E N "_WindowText" E N "_Window" E E
+ E E
+27 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+1
+"layoutAlignment" "AlignNone"
+1
+LANG:1 31 Sans Serif,-1,12,5,50,0,0,0,0,0
+0  253 125 306 159
+3 "0s" 0 0 0 1 0 -1  E "// SimpleCtrlScriptStart {invalid}
+main()
+{
+  EP_textFieldIn();
+  EP_setBackColor();
+}
+
+void EP_textFieldIn()
+{
+  dyn_errClass err;
+
+  if( !dpExists( $dpChnName+\".actual.Trip:_online.._value\"))
+  {
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+    return;
+  }
+
+  dpConnect(\"EP_textFieldInCB\",
+            $dpChnName+\".actual.Trip:_online.._value\");
+  err = getLastError();
+  if (dynlen(err) > 0)
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+
+}
+
+void EP_textFieldInCB(string dp, bool boNewValue)
+{
+  setValue(\"\", \"text\", dpValToString(dp, boNewValue, FALSE) );
+}
+
+
+void EP_setBackColor()
+{
+  dyn_errClass err;
+
+  if( !dpExists( $dpChnName+\".actual.Trip:_online.._value\"))
+  {
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+    return;
+  }
+
+  dpConnect(\"EP_setBackColorCB\", 
+            $dpChnName+\".actual.Trip:_online.._value\");
+  err = getLastError();
+  if (dynlen(err) > 0)
+    setValue(\"\", \"color\", \"_dpdoesnotexist\");
+
+}
+
+
+void EP_setBackColorCB(string dpSource, bool boNewValue)
+{
+  if (!boNewValue)
+    setValue(\"\", \"backCol\", \"white\");
+  else
+    setValue(\"\", \"backCol\", \"{248,69,105,232}\");
+}
+
+
+// SimpleCtrlScript {EP_textFieldIn}
+// DP {cms_gem_dcs_1:CAEN/904_Shared_mainframe/board02/channel000.actual.Trip}
+// DPConfig {:_online.._value}
+// DPType {bool}
+// UseDPUnit {FALSE}
+// UseDPFormat {TRUE}
+// SimpleCtrlScriptEnd {EP_textFieldIn}
+" 0
+ E
+2 29
+"PRIMITIVE_TEXT12"
+""
+1 70 50 E E E 1 E 1 E N "_WindowText" E N "_Window" E E
+ E E
+28 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+4
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+"transformable" "0"
+E E 0 1 3 2 1 E 0.6062176165803109 0 0.4074074074074074 135.5647668393783 85.62962962962963 0 E 70 50 180 100
+0 2 2 "0s" 0 0 0 64 0 0  70 50 1
+1
+LANG:1 31 Sans Serif,-1,12,5,50,0,0,0,0,0
+0 1
+LANG:1 7 Rmp Dir
+2 30
+"PRIMITIVE_TEXT13"
+""
+1 70 50 E E E 1 E 1 E N "_WindowText" E N "_Window" E E
+ E E
+29 0 0 0 0 0
+E E E
+0
+1
+LANG:1 0 
+
+4
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+"transformable" "0"
+E E 0 1 3 2 1 E 0.6062176165803109 0 0.4074074074074074 135.5647668393783 116.6296296296296 0 E 70 50 180 100
+0 2 2 "0s" 0 0 0 64 0 0  70 50 1
+1
+LANG:1 31 Sans Serif,-1,12,5,50,0,0,0,0,0
+0 1
+LANG:1 4 Trip
+1 34 0 "" 2
+0
+30 33
+"FRAME3"
+""
+1 179 142 E E E 1 E 1 E N "_WindowText" E N {0,0,0} E E
+ E E
+35 0 0 0 0 0
+E E E
+1
+1
+LANG:1 0 
+
+3
+"layoutAlignment" "AlignNone"
+"dashclr"N "_Transparent"
+"antiAliased" "0"
+E E 0 1 3 2 1 E 1.021276595744681 0 0.8223593964334708 -12.80851063829787 44.4101508916323 0 E 179 142 321 251
+1
+LANG:1 30 Sans Serif,-1,8,5,50,0,0,0,0,0
+0 1
+LANG:1 0 
+0
+LAYER, 1 
+1
+LANG:1 0 
+0
+LAYER, 2 
+1
+LANG:1 0 
+0
+LAYER, 3 
+1
+LANG:1 0 
+0
+LAYER, 4 
+1
+LANG:1 0 
+0
+LAYER, 5 
+1
+LANG:1 0 
+0
+LAYER, 6 
+1
+LANG:1 0 
+0
+LAYER, 7 
+1
+LANG:1 0 
+0
+3 0 "Channel" -1
+"layoutAlignment" "AlignNone"
+"" ""
+"objects/fwTrending/fwTrendingPlotOpenButton.pnl" 192.8963730569948 260.03125 T 33 1.539184404264746 0 0.58 -146.9030890485607 24.18187500000002
+2
+"$plotName""cms_gem_dcs_1:Channel"
+"$templateParameters"""
+0


### PR DESCRIPTION
Original name refpmt.pnl was changed to 904_GEM_PMT_ref.pnl.
Original name cosmic_HV_Panel.pnl was changed to 904_GEM_PMT_panel.pnl
Improvements: Display format of numbers - now limited to 1 decimal place
                         Units added to labels
                         Ramping direction now displayed as up or down instead of 0 or 1.
                         Button geometry and colours changed
                         Alignment and sizes of widgets adjusted.